### PR TITLE
fix(mux-direct-upload-tutorial): Make env variables in server consistent with tutorial

### DIFF
--- a/final-server.js
+++ b/final-server.js
@@ -27,8 +27,8 @@ const options = {
     Accept: 'application/json',
   },
   auth: {
-    username: process.env.API_USERNAME,
-    password: process.env.API_KEY,
+    username: process.env.MUX_ACCESS_TOKEN_ID,
+    password: process.env.MUX_SECRET_KEY,
   },
   mode: 'cors',
 }

--- a/server.js
+++ b/server.js
@@ -27,8 +27,8 @@ const options = {
     Accept: 'application/json',
   },
   auth: {
-    username: process.env.API_USERNAME,
-    password: process.env.API_KEY,
+    username: process.env.MUX_ACCESS_TOKEN_ID,
+    password: process.env.MUX_SECRET_KEY,
   },
   mode: 'cors',
 }


### PR DESCRIPTION
## Description

A community member was following [this direct uploads tutorial](https://www.mux.com/blog/direct-uploads-with-mux-upload-button) and realized they were getting an error from mismatched environment variable names between the tutorial and the variable names in the `server` files. 

This PR makes the servers consistent with the tutorial. 

Closes https://github.com/clearlyTHUYDOAN/mux-direct-upload/issues/1.